### PR TITLE
Reads thumbprint of desired X509 certificate from file

### DIFF
--- a/PluginVersion.txt
+++ b/PluginVersion.txt
@@ -1,3 +1,3 @@
 ﻿:
-SmartCertificateKeyProviderPlugin:2.0.1
+SmartCertificateKeyProviderPlugin:2.0.2
 :

--- a/PluginVersion.txt
+++ b/PluginVersion.txt
@@ -1,3 +1,1 @@
-﻿:
-SmartCertificateKeyProviderPlugin:
-:
+﻿SmartCertificateKeyProviderPlugin: 2.0.3

--- a/PluginVersion.txt
+++ b/PluginVersion.txt
@@ -1,3 +1,3 @@
 ﻿:
-SmartCertificateKeyProviderPlugin:2.0.2
+SmartCertificateKeyProviderPlugin:
 :

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -20,3 +20,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1fbc0e45-0c76-4346-967b-10d681fb712e")]
+[assembly: AssemblyVersion("2.0.0.2")]
+[assembly: AssemblyFileVersion("2.0.0.2")]

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("SmartCertificateKeyProviderPlugin")]
-[assembly: AssemblyDescription("This plugin uses X.509 certificate from your personal certificate storage to encrypt KeePass database with generated SHA1 hash from certificate's signature. It also allow to use certificates that are on your Smart Card. It is possible to use Secure Desktop feature (needs to be enabled in Options - Security tab) to avoid Keyloggers.\nDON'T LOOSE YOUR CERTIFICATE OR YOU WILL NOT BE ABLE TO OPEN YOUR DATABASE.")]
+[assembly: AssemblyDescription("This plugin uses X.509 certificate from your personal certificate storage to encrypt KeePass database with generated SHA1 hash from certificate's signature. It also allow to use certificates that are on your Smart Card. It is possible to use Secure Desktop feature (needs to be enabled in Options - Security tab) to avoid Keyloggers.\nDON'T LOSE YOUR CERTIFICATE OR YOU WILL NOT BE ABLE TO OPEN YOUR DATABASE.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("BodnarSoft")]
 [assembly: AssemblyProduct("KeePass Plugin")]

--- a/Source/Smart Certificate KeyProvider.csproj
+++ b/Source/Smart Certificate KeyProvider.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\GitVersion.MsBuild.6.5.0\build\GitVersion.MsBuild.props" Condition="Exists('packages\GitVersion.MsBuild.6.5.0\build\GitVersion.MsBuild.props')" />
   <Import Project="packages\GitVersionTask.5.1.3\build\GitVersionTask.props" Condition="Exists('packages\GitVersionTask.5.1.3\build\GitVersionTask.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -79,8 +80,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\GitVersionTask.5.1.3\build\GitVersionTask.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\GitVersionTask.5.1.3\build\GitVersionTask.props'))" />
-    <Error Condition="!Exists('packages\GitVersionTask.5.1.3\build\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\GitVersionTask.5.1.3\build\GitVersionTask.targets'))" />
+    <Error Condition="!Exists('packages\GitVersion.MsBuild.6.5.0\build\GitVersion.MsBuild.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\GitVersion.MsBuild.6.5.0\build\GitVersion.MsBuild.props'))" />
+    <Error Condition="!Exists('packages\GitVersion.MsBuild.6.5.0\build\GitVersion.MsBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\GitVersion.MsBuild.6.5.0\build\GitVersion.MsBuild.targets'))" />
   </Target>
-  <Import Project="packages\GitVersionTask.5.1.3\build\GitVersionTask.targets" Condition="Exists('packages\GitVersionTask.5.1.3\build\GitVersionTask.targets')" />
+  <Import Project="packages\GitVersion.MsBuild.6.5.0\build\GitVersion.MsBuild.targets" Condition="Exists('packages\GitVersion.MsBuild.6.5.0\build\GitVersion.MsBuild.targets')" />
 </Project>

--- a/Source/Smart Certificate KeyProvider.csproj
+++ b/Source/Smart Certificate KeyProvider.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\GitVersionTask.5.1.3\build\GitVersionTask.props" Condition="Exists('packages\GitVersionTask.5.1.3\build\GitVersionTask.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -61,32 +62,25 @@
     <None Include="packages.config" />
     <None Include="Smart Certificate KeyProvider.ruleset" />
   </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
-  </Target>
   <Target Name="WriteVersionFile" AfterTargets="Build">
     <ItemGroup>
-      <PluginVersion Include=":"/>
-      <PluginVersion Include="$(TargetName):$(GitVersion_MajorMinorPatch)"/>
-      <PluginVersion Include=":"/>
+      <PluginVersion Include=":" />
+      <PluginVersion Include="$(TargetName):$(GitVersion_MajorMinorPatch)" />
+      <PluginVersion Include=":" />
     </ItemGroup>
-    <WriteLinesToFile
-      File="$(SolutionDir)..\PluginVersion.txt"
-      Lines="@(PluginVersion)"
-      Overwrite="true"
-      Encoding="UTF-8"/>
+    <WriteLinesToFile File="$(SolutionDir)..\PluginVersion.txt" Lines="@(PluginVersion)" Overwrite="true" Encoding="UTF-8" />
   </Target>
   <PropertyGroup>
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\GitVersionTask.5.1.3\build\GitVersionTask.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\GitVersionTask.5.1.3\build\GitVersionTask.props'))" />
+    <Error Condition="!Exists('packages\GitVersionTask.5.1.3\build\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\GitVersionTask.5.1.3\build\GitVersionTask.targets'))" />
+  </Target>
+  <Import Project="packages\GitVersionTask.5.1.3\build\GitVersionTask.targets" Condition="Exists('packages\GitVersionTask.5.1.3\build\GitVersionTask.targets')" />
 </Project>

--- a/Source/Smart Certificate KeyProvider.sln
+++ b/Source/Smart Certificate KeyProvider.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11205.157 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Smart Certificate KeyProvider", "Smart Certificate KeyProvider.csproj", "{1FBC0E45-0C76-4346-967B-10D681FB712E}"
 EndProject
@@ -17,10 +17,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Debug|Any CPU.Build.0 = Release|Any CPU
-		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Smart Certificate KeyProvider.sln
+++ b/Source/Smart Certificate KeyProvider.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2011
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Smart Certificate KeyProvider", "Smart Certificate KeyProvider.csproj", "{1FBC0E45-0C76-4346-967B-10D681FB712E}"
 EndProject
@@ -17,10 +17,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FBC0E45-0C76-4346-967B-10D681FB712E}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/SmartCertificateKeyProvider.cs
+++ b/Source/SmartCertificateKeyProvider.cs
@@ -39,8 +39,13 @@
                     X509Certificate2Collection matching_certificates = myStore.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, true);
                     certificates = matching_certificates.Cast<X509Certificate2>().ToArray();
                 }
+                else
+                {
+                    System.IO.StreamWriter file = new System.IO.StreamWriter(@"X509_thumbprint.txt");
+                    file.Close();
+                }
 
-                myStore.Close();
+                    myStore.Close();
 
                 return certificates;
             }
@@ -118,12 +123,12 @@
             {
                 try
                 {
-                    if (certificate.PrivateKey is RSA rsa)
+		    using (RSACng rsaCng = certificate.GetRSAPrivateKey() as RSACng)
                     {
                         CertificateCache.StoreCachedValue(keyProviderQueryContext.DatabasePath, certificate.Thumbprint);
 
                         // Using HashAlgorithmName.SHA1 for backward compatibility
-                        return rsa.SignData(DataToSign, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1); // DO NOT CHANGE THIS!!!!;
+                        return rsaCng.SignData(DataToSign, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1); // DO NOT CHANGE THIS!!!!;
                     }
                 }
                 catch (Exception ex)

--- a/Source/SmartCertificateKeyProvider.cs
+++ b/Source/SmartCertificateKeyProvider.cs
@@ -27,9 +27,18 @@
                 var myStore = new X509Store(StoreName.My, StoreLocation.CurrentUser);
                 myStore.Open(OpenFlags.ReadOnly);
 
-                var certificates = myStore.Certificates.Cast<X509Certificate2>()
-                                          .Where(c => c.HasPrivateKey)
-                                          .ToArray();
+                X509Certificate2[] certificates = myStore.Certificates.Cast<X509Certificate2>()
+                                                        .Where(c => c.HasPrivateKey)
+                                                        .ToArray();
+
+                if (System.IO.File.Exists("X509_thumbprint.txt"))
+                {
+                    System.IO.StreamReader file = new System.IO.StreamReader(@"X509_thumbprint.txt");
+                    string thumbprint = file.ReadLine();
+                    file.Close();
+                    X509Certificate2Collection matching_certificates = myStore.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, true);
+                    certificates = matching_certificates.Cast<X509Certificate2>().ToArray();
+                }
 
                 myStore.Close();
 

--- a/Source/SmartCertificateKeyProviderPluginExt.cs
+++ b/Source/SmartCertificateKeyProviderPluginExt.cs
@@ -15,7 +15,7 @@
 
         #region Public properties
 
-        public override string UpdateUrl => "https://raw.githubusercontent.com/BodnarSoft/KeePass-Smart-Certificate-Key-Provider/master/PluginVersion.txt";
+        public override string UpdateUrl => "https://raw.githubusercontent.com/jimmyswimmy/KeePass-Smart-Certificate-Key-Provider/master/PluginVersion.txt";
 
         #endregion
 

--- a/Source/packages.config
+++ b/Source/packages.config
@@ -1,11 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GitVersionTask"
-           version="3.6.5"
-           targetFramework="net471"
-           developmentDependency="true" />
-  <package id="StyleCop.Analyzers"
-           version="1.0.2"
-           targetFramework="net471"
-           developmentDependency="true" />
+  <package id="GitVersion.MsBuild" version="6.5.0" targetFramework="net471" developmentDependency="true" />
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net471" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
I wanted to be able to not always have to select the X509 certificate when I start Keepass. I'm not a C# programmer (or .net, man there's a lot in there) so this could be a lot cleaner I'm sure; it's built from stackoverflow and ms.com snippets.

Anyway, this reads a "X509_thumbprint.txt" file in the main keepass directory, if it exists. If so, it reads the thumbprint (the first/only line of the file, probably this won't work if there's a CR/LF, I didn't care) from the file, and searches for that.

Probably this gives weird behavior if there IS such a file and no perfectly matching certificate. I didn't test for that.

Also, this is the first time I've ever attempted any kind of pull request, not sure what it's supposed to contain. Use it if you want it, ignore if you don't.