### PR TITLE
Move from CSP to KSP cypto service (KB5066835, CVE-2024-30098), Issue #14.

### DIFF
--- a/PluginVersion.txt
+++ b/PluginVersion.txt
@@ -1,3 +1,3 @@
 ﻿:
-SmartCertificateKeyProviderPlugin:2.0.1
+SmartCertificateKeyProviderPlugin:2.0.2
 :

--- a/Source/SmartCertificateKeyProvider.cs
+++ b/Source/SmartCertificateKeyProvider.cs
@@ -109,12 +109,12 @@
             {
                 try
                 {
-                    if (certificate.PrivateKey is RSA rsa)
+                    using (RSACng rsaCng = certificate.GetRSAPrivateKey() as RSACng)
                     {
                         CertificateCache.StoreCachedValue(keyProviderQueryContext.DatabasePath, certificate.Thumbprint);
 
                         // Using HashAlgorithmName.SHA1 for backward compatibility
-                        return rsa.SignData(DataToSign, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1); // DO NOT CHANGE THIS!!!!;
+                        return rsaCng.SignData(DataToSign, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1); // DO NOT CHANGE THIS!!!!;
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Resolves Issue #14 by moving from the Cryptographic Service Provider (CSP), which has been deprecated by Microsoft ([KB5066835](https://support.microsoft.com/en-us/topic/october-14-2025-kb5066835-os-builds-26200-6899-and-26100-6899-1db237d8-9f3b-4218-9515-3e0a32729685), [temporary resolution](https://learn.microsoft.com/en-us/windows/release-health/resolved-issues-windows-11-25h2#3697msgdesc), [Related to CVE-2024-30098](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-30098)), to a Key Storage Provider (KSP) for RSA-based certificates.

The only change is to access the RSA PrivateKey using certificate.GetRSAPrivateKey() as RSACng.