### PR TITLE
Modernize Smart Certificate KeyProvider

### DIFF
--- a/PluginVersion.txt
+++ b/PluginVersion.txt
@@ -1,3 +1,4 @@
 ﻿:
-SmartCertificateKeyProviderPlugin:2.0.1
+SmartCertificateKeyProviderPlugin:2.0.2
 :
+

--- a/Source/SmartCertificateKeyProvider.cs
+++ b/Source/SmartCertificateKeyProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace SmartCertificateKeyProviderPlugin
+namespace SmartCertificateKeyProviderPlugin
 {
     using System;
     using System.Linq;
@@ -109,13 +109,15 @@
             {
                 try
                 {
-                    if (certificate.PrivateKey is RSA rsa)
-                    {
-                        CertificateCache.StoreCachedValue(keyProviderQueryContext.DatabasePath, certificate.Thumbprint);
+					using (RSA rsa = certificate.GetRSAPrivateKey())
+					{
+						if (rsa != null)
+						{
+							CertificateCache.StoreCachedValue(keyProviderQueryContext.DatabasePath, certificate.Thumbprint);
 
-                        // Using HashAlgorithmName.SHA1 for backward compatibility
-                        return rsa.SignData(DataToSign, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1); // DO NOT CHANGE THIS!!!!;
-                    }
+							return rsa.SignData(DataToSign, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
+						}
+					}
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
- Replaced legacy certificate.PrivateKey usage with certificate.GetRSAPrivateKey() to align with current Windows cryptography APIs (CNG).
- Verified compatibility with x64 portable KeePass 2.60.
- Updated build configuration to target .NET Framework 4.8 and x64 architecture.
- Adjusted output path for direct deployment into KeePass’s Plugins folder.

Compatibility Notes
- New databases created with this plugin encrypt/decrypt successfully with pivkey smart cards. Additional hardware testing would be prudent.
- Legacy databases originally encrypted under CSP providers may not open on modern OS builds.